### PR TITLE
Add org fields

### DIFF
--- a/modules/app/admin/model.py
+++ b/modules/app/admin/model.py
@@ -18,7 +18,7 @@ class UserForm(form.Form):
     eppn = fields.StringField('EPPN')
     first_name = fields.StringField('First name', [validators.DataRequired()])
     last_name = fields.StringField('Last name', [validators.DataRequired()])
-    email = fields.StringField('Email', [validators.Email()])
+    email = fields.StringField('Email', [validators.Optional(), validators.Email()])
     phone_numbers = fields.FieldList(
         fields.StringField(''), min_entries=1)
     fax_numbers = fields.FieldList(
@@ -30,7 +30,7 @@ class UserForm(form.Form):
 
 class UserView(ModelView):
     column_list = ('targetted_id', 'eppn', 'first_name',
-                   'last_name', 'email', 'phone_numbers', 'fax_numbers', 'role', 'job_title', 'organization_id')
+                   'last_name', 'email', 'phone_numbers', 'fax_numbers', 'role', 'job_title', 'organization.name')
     column_sortable_list = ('eppn', 'first_name', 'last_name', 'email', 'role')
 
     form = UserForm
@@ -78,17 +78,34 @@ class ClientView(ModelView):
 
 class OrganizationForm(form.Form):
     name = fields.StringField('Name', [validators.DataRequired()])
+    short_name = fields.StringField('Short Name for Org')
+    code = fields.StringField('Org Code')
     care_of = fields.StringField('Care of')
     street = fields.StringField('Street')
+    extended_address = fields.StringField('Extended Address')
     city = fields.StringField('City')
     state = fields.StringField('State')
     postal_code = fields.StringField('Postal Code')
+    country_name = fields.SelectField('Country', 
+        choices=[('', ''), ('United States', 'United States'), ('United Kingdom', 'United Kingdom')]
+    )
+
+    def validate(self):
+        rv = super(OrganizationForm, self).validate()
+        if not rv:
+            return False
+
+        if self.extended_address.data and not self.street.data:
+            self.extended_address.errors.append("Street required to define extended")
+            return False
+        return rv
+       
 
 
 class OrganizationView(ModelView):
-    column_list = ('name', 'care_of', 'street', 'city', 'state', 'postal_code')
-    column_sortable_list = ('name', 'city', 'state')
-
+    column_list = ('name', 'short_name', 'code', 'care_of', 'street', 'extended_address','city', 'state', 'postal_code', 'country_name')
+    column_sortable_list = ('name', 'city', 'state', 'code')
+    
     form = OrganizationForm
 
 

--- a/modules/app/admin/model.py
+++ b/modules/app/admin/model.py
@@ -30,7 +30,7 @@ class UserForm(form.Form):
 
 class UserView(ModelView):
     column_list = ('targetted_id', 'eppn', 'first_name',
-                   'last_name', 'email', 'phone_numbers', 'fax_numbers', 'role', 'job_title', 'organization.name')
+                   'last_name', 'email', 'phone_numbers', 'fax_numbers', 'role', 'job_title', 'organization_id')
     column_sortable_list = ('eppn', 'first_name', 'last_name', 'email', 'role')
 
     form = UserForm

--- a/modules/app/schemas/organization.py
+++ b/modules/app/schemas/organization.py
@@ -7,10 +7,19 @@ _org_schema = {
         "name": {
             "type": "string"
         },
+        "code": {
+            "type": "string"
+        },
+        "short_name": {
+            "type": "string"
+        },
         "care_of": {
             "type": "string"
         },
         "street": {
+            "type": "string"
+        },
+        "extended_address": {
             "type": "string"
         },
         "city": {
@@ -21,9 +30,15 @@ _org_schema = {
         },
         "postal_code": {
             "type": "string"
+        },
+        "country_name": {
+            "type": "string"
         }
     },
-    "required": ["name"]
+    "required": ["name"],
+    "dependencies": {
+        "extended_address": [ "street_address" ]
+    }
 }
 
 


### PR DESCRIPTION
Took out the reference to organization.name in the user fields list. You *can* make it work by overriding get_list_value in the modelview and loading the org object but I think there is probably a better way to do it I am not seeing so I am going to hold off for now.